### PR TITLE
Lab 10: setup2.ps1: AllowBlobPublicAccess = $true

### DIFF
--- a/Allfiles/10/setup2.ps1
+++ b/Allfiles/10/setup2.ps1
@@ -33,6 +33,7 @@ $StorageHT = @{
      Name              = $storageName 
      SkuName           = 'Standard_LRS'  
      Location          = $location
+     AllowBlobPublicAccess = $true
 }
 $StorageAccount = New-AzStorageAccount @StorageHT
 


### PR DESCRIPTION
- Lab 10: Improve performance with hybrid tables
- Task: Deploy an Azure SQL Database

When running the deployment script at the above-referenced task, an error `New-AzStorageContainer : Public access is not permitted on this storage account` is encountered and resources are not fully deployed. Warning messages advising of an "upcoming" change to disallowing public access appear in previous output.

Modifying the script to specify a parameter to allow public access on the storage account allowed the script to succeed in tests.

Changes proposed in this pull request:

- Add `AllowBlobPublicAccess = $true` to storage account parameters in `setup2.ps1`

Current main:
![image](https://github.com/MicrosoftLearning/DP-500-Azure-Data-Analyst/assets/134323425/311da0ee-6403-4107-895a-9d44e8397ec6)

Proposed changes:
![image](https://github.com/MicrosoftLearning/DP-500-Azure-Data-Analyst/assets/134323425/d5a44a8d-e6c8-42b4-be3f-0359fa5219c4)
